### PR TITLE
Fix crash after several minutes of usage.

### DIFF
--- a/src/classFactory.cpp
+++ b/src/classFactory.cpp
@@ -9,7 +9,15 @@
 #include <windows.h>
 #include "syntherceptor.h"
 
-static long g_lockCount = 0;
+std::atomic<ULONG> refCount{0};
+
+void DllAddRef() {
+	++refCount;
+}
+
+void DllRelease() {
+	--refCount;
+}
 
 class ClassFactory : public IClassFactory {
 	public:
@@ -40,9 +48,9 @@ class ClassFactory : public IClassFactory {
 
 	STDMETHODIMP LockServer(BOOL lock) {
 		if (lock)
-			InterlockedIncrement(&g_lockCount);
+			DllAddRef();
 		else
-			InterlockedDecrement(&g_lockCount);
+			DllRelease();
 		return S_OK;
 	}
 };
@@ -61,7 +69,7 @@ STDAPI DllGetClassObject(REFCLSID clsid, REFIID riid, void** ppv) {
 }
 
 STDAPI DllCanUnloadNow() {
-	return g_lockCount == 0 ? S_OK : S_FALSE;
+	return refCount == 0 ? S_OK : S_FALSE;
 }
 
 BOOL WINAPI DllMain(HINSTANCE, DWORD, LPVOID) {

--- a/src/syntherceptor.cpp
+++ b/src/syntherceptor.cpp
@@ -12,7 +12,9 @@
 
 #include "nvdaController.h"
 
-Syntherceptor::Syntherceptor() : refCount(1) {}
+Syntherceptor::Syntherceptor() : refCount(0) {
+	DllAddRef();
+}
 
 STDMETHODIMP Syntherceptor::QueryInterface(REFIID riid, void** ppv) {
 	if (!ppv)
@@ -36,8 +38,10 @@ ULONG Syntherceptor::AddRef() {
 
 ULONG Syntherceptor::Release() {
 	ULONG c = --refCount;
-	if (!c)
+	if (!c) {
 		delete this;
+		DllRelease();
+	}
 	return c;
 }
 

--- a/src/syntherceptor.h
+++ b/src/syntherceptor.h
@@ -41,3 +41,7 @@ class Syntherceptor : public ISpTTSEngine, public ISpObjectWithToken {
 	std::atomic<ULONG> refCount;
 	CComPtr<ISpObjectToken> token;
 };
+
+// Implemented in classFactory.cpp
+void DllAddRef();
+void DllRelease();


### PR DESCRIPTION
We now consider live instances of the Syntherceptor class in DllCanUnloadNow, rather than just calls to ClassFactory::Lock, which it seems SAPI never calls. Previously, the dll was being unloaded while an instance of Syntherceptor was still alive, causing a crash the next time SAPI tried to call it. This also fixes the initial ref count of Syntherceptor instances to avoid a memory leak.
Fixes #2.