### PR TITLE
Fix installation on 32 bit systems.

### DIFF
--- a/syntherceptor.nsi
+++ b/syntherceptor.nsi
@@ -3,10 +3,12 @@
 ; Copyright 2025 James Teh
 ; License: GNU General Public License version 2.0
 
+!include LogicLib.nsh
 ; We don't really need MUI2, but without it, the uninstaller is corrupt when
 ; built on GitHub Actions. See:
 ; https://stackoverflow.com/questions/75525495/nsis-installer-produces-an-app-that-cant-run-this-app-cant-run-on-your-pc-t
 !include "MUI2.nsh"
+!include "x64.nsh"
 
 Name "Syntherceptor"
 OutFile "${OUTFILE}"
@@ -22,24 +24,9 @@ Section "Install"
 	SetOutPath "$INSTDIR"
 
 	CreateDirectory "$INSTDIR\x86"
-	CreateDirectory "$INSTDIR\x64"
-
 	File /oname=$INSTDIR\x86\syntherceptor.dll "build\x86\syntherceptor.dll"
 	File /oname=$INSTDIR\x86\nvdaControllerClient.dll "deps\nvdaControllerClient\x86\nvdaControllerClient.dll"
 
-	File /oname=$INSTDIR\x64\syntherceptor.dll "build\x86_64\syntherceptor.dll"
-	File /oname=$INSTDIR\x64\nvdaControllerClient.dll "deps\nvdaControllerClient\x64\nvdaControllerClient.dll"
-
-	WriteUninstaller "$INSTDIR\Uninstall.exe"
-
-	; Add/Remove Programs entry
-	WriteRegStr HKLM "Software\Microsoft\Windows\CurrentVersion\Uninstall\Syntherceptor" "DisplayName" "Syntherceptor"
-	WriteRegStr HKLM "Software\Microsoft\Windows\CurrentVersion\Uninstall\Syntherceptor" "UninstallString" "$INSTDIR\Uninstall.exe"
-	WriteRegStr HKLM "Software\Microsoft\Windows\CurrentVersion\Uninstall\Syntherceptor" "InstallLocation" "$INSTDIR"
-	WriteRegStr HKLM "Software\Microsoft\Windows\CurrentVersion\Uninstall\Syntherceptor" "Publisher" "James Teh"
-	WriteRegStr HKLM "Software\Microsoft\Windows\CurrentVersion\Uninstall\Syntherceptor" "DisplayVersion" "1.0"
-
-	; 32-bit SAPI keys
 	SetRegView 32
 	WriteRegStr HKLM "SOFTWARE\Microsoft\Speech\Voices\Tokens\syntherceptor" "" "Syntherceptor"
 	WriteRegStr HKLM "SOFTWARE\Microsoft\Speech\Voices\Tokens\syntherceptor" "CLSID" "{a2f5f730-cf28-4ac7-8f7f-0e69a6d10c35}"
@@ -55,29 +42,45 @@ Section "Install"
 	WriteRegStr HKLM "SOFTWARE\Classes\CLSID\{a2f5f730-cf28-4ac7-8f7f-0e69a6d10c35}\InprocServer32" "" "$INSTDIR\x86\syntherceptor.dll"
 	WriteRegStr HKLM "SOFTWARE\Classes\CLSID\{a2f5f730-cf28-4ac7-8f7f-0e69a6d10c35}\InprocServer32" "ThreadingModel" "Both"
 
-	; 64-bit SAPI keys
-	SetRegView 64
-	WriteRegStr HKLM "SOFTWARE\Microsoft\Speech\Voices\Tokens\syntherceptor" "" "Syntherceptor"
-	WriteRegStr HKLM "SOFTWARE\Microsoft\Speech\Voices\Tokens\syntherceptor" "CLSID" "{a2f5f730-cf28-4ac7-8f7f-0e69a6d10c35}"
-	WriteRegStr HKLM "SOFTWARE\Microsoft\Speech\Voices\Tokens\syntherceptor" "VoiceName" "en"
+	${If} ${RunningX64}
+		CreateDirectory "$INSTDIR\x64"
+		File /oname=$INSTDIR\x64\syntherceptor.dll "build\x86_64\syntherceptor.dll"
+		File /oname=$INSTDIR\x64\nvdaControllerClient.dll "deps\nvdaControllerClient\x64\nvdaControllerClient.dll"
 
-	WriteRegStr HKLM "SOFTWARE\Microsoft\Speech\Voices\Tokens\syntherceptor\Attributes" "Age" "Adult"
-	WriteRegStr HKLM "SOFTWARE\Microsoft\Speech\Voices\Tokens\syntherceptor\Attributes" "Gender" "Male"
-	WriteRegStr HKLM "SOFTWARE\Microsoft\Speech\Voices\Tokens\syntherceptor\Attributes" "Language" "9"
-	WriteRegStr HKLM "SOFTWARE\Microsoft\Speech\Voices\Tokens\syntherceptor\Attributes" "Vendor" "James Teh"
-	WriteRegStr HKLM "SOFTWARE\Microsoft\Speech\Voices\Tokens\syntherceptor\Attributes" "Version" "1.0"
+		SetRegView 64
+		WriteRegStr HKLM "SOFTWARE\Microsoft\Speech\Voices\Tokens\syntherceptor" "" "Syntherceptor"
+		WriteRegStr HKLM "SOFTWARE\Microsoft\Speech\Voices\Tokens\syntherceptor" "CLSID" "{a2f5f730-cf28-4ac7-8f7f-0e69a6d10c35}"
+		WriteRegStr HKLM "SOFTWARE\Microsoft\Speech\Voices\Tokens\syntherceptor" "VoiceName" "en"
 
-	WriteRegStr HKLM "SOFTWARE\Classes\CLSID\{a2f5f730-cf28-4ac7-8f7f-0e69a6d10c35}" "" "syntherceptor.ttsEngine"
-	WriteRegStr HKLM "SOFTWARE\Classes\CLSID\{a2f5f730-cf28-4ac7-8f7f-0e69a6d10c35}\InprocServer32" "" "$INSTDIR\x64\syntherceptor.dll"
-	WriteRegStr HKLM "SOFTWARE\Classes\CLSID\{a2f5f730-cf28-4ac7-8f7f-0e69a6d10c35}\InprocServer32" "ThreadingModel" "Both"
+		WriteRegStr HKLM "SOFTWARE\Microsoft\Speech\Voices\Tokens\syntherceptor\Attributes" "Age" "Adult"
+		WriteRegStr HKLM "SOFTWARE\Microsoft\Speech\Voices\Tokens\syntherceptor\Attributes" "Gender" "Male"
+		WriteRegStr HKLM "SOFTWARE\Microsoft\Speech\Voices\Tokens\syntherceptor\Attributes" "Language" "9"
+		WriteRegStr HKLM "SOFTWARE\Microsoft\Speech\Voices\Tokens\syntherceptor\Attributes" "Vendor" "James Teh"
+		WriteRegStr HKLM "SOFTWARE\Microsoft\Speech\Voices\Tokens\syntherceptor\Attributes" "Version" "1.0"
+
+		WriteRegStr HKLM "SOFTWARE\Classes\CLSID\{a2f5f730-cf28-4ac7-8f7f-0e69a6d10c35}" "" "syntherceptor.ttsEngine"
+		WriteRegStr HKLM "SOFTWARE\Classes\CLSID\{a2f5f730-cf28-4ac7-8f7f-0e69a6d10c35}\InprocServer32" "" "$INSTDIR\x64\syntherceptor.dll"
+		WriteRegStr HKLM "SOFTWARE\Classes\CLSID\{a2f5f730-cf28-4ac7-8f7f-0e69a6d10c35}\InprocServer32" "ThreadingModel" "Both"
+	${EndIf}
+
+	WriteUninstaller "$INSTDIR\Uninstall.exe"
+
+	; Add/Remove Programs entry
+	WriteRegStr HKLM "Software\Microsoft\Windows\CurrentVersion\Uninstall\Syntherceptor" "DisplayName" "Syntherceptor"
+	WriteRegStr HKLM "Software\Microsoft\Windows\CurrentVersion\Uninstall\Syntherceptor" "UninstallString" "$INSTDIR\Uninstall.exe"
+	WriteRegStr HKLM "Software\Microsoft\Windows\CurrentVersion\Uninstall\Syntherceptor" "InstallLocation" "$INSTDIR"
+	WriteRegStr HKLM "Software\Microsoft\Windows\CurrentVersion\Uninstall\Syntherceptor" "Publisher" "James Teh"
+	WriteRegStr HKLM "Software\Microsoft\Windows\CurrentVersion\Uninstall\Syntherceptor" "DisplayVersion" "1.0"
 
 	MessageBox MB_YESNO|MB_ICONQUESTION "Set Syntherceptor as the default SAPI voice for this user?" IDYES setDefault IDNO skipDefault
 
 setDefault:
-	SetRegView 64
-	WriteRegStr HKCU "SOFTWARE\Microsoft\Speech\Voices" "DefaultTokenId" "HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Speech\Voices\Tokens\syntherceptor"
 	SetRegView 32
 	WriteRegStr HKCU "SOFTWARE\Microsoft\Speech\Voices" "DefaultTokenId" "HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Speech\Voices\Tokens\syntherceptor"
+	${If} ${RunningX64}
+		SetRegView 64
+		WriteRegStr HKCU "SOFTWARE\Microsoft\Speech\Voices" "DefaultTokenId" "HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Speech\Voices\Tokens\syntherceptor"
+	${EndIf}
 
 skipDefault:
 SectionEnd
@@ -88,20 +91,19 @@ Section "Uninstall"
 	SetRegView 32
 	DeleteRegKey HKLM "SOFTWARE\Microsoft\Speech\Voices\Tokens\syntherceptor"
 	DeleteRegKey HKLM "SOFTWARE\Classes\CLSID\{a2f5f730-cf28-4ac7-8f7f-0e69a6d10c35}"
-
-	SetRegView 64
-	DeleteRegKey HKLM "SOFTWARE\Microsoft\Speech\Voices\Tokens\syntherceptor"
-	DeleteRegKey HKLM "SOFTWARE\Classes\CLSID\{a2f5f730-cf28-4ac7-8f7f-0e69a6d10c35}"
-
 	Delete "$INSTDIR\x86\syntherceptor.dll"
 	Delete "$INSTDIR\x86\nvdaControllerClient.dll"
+	RMDir "$INSTDIR\x86"
 
-	Delete "$INSTDIR\x64\syntherceptor.dll"
-	Delete "$INSTDIR\x64\nvdaControllerClient.dll"
+	${If} ${RunningX64}
+		SetRegView 64
+		DeleteRegKey HKLM "SOFTWARE\Microsoft\Speech\Voices\Tokens\syntherceptor"
+		DeleteRegKey HKLM "SOFTWARE\Classes\CLSID\{a2f5f730-cf28-4ac7-8f7f-0e69a6d10c35}"
+		Delete "$INSTDIR\x64\syntherceptor.dll"
+		Delete "$INSTDIR\x64\nvdaControllerClient.dll"
+		RMDir "$INSTDIR\x64"
+	${EndIf}
 
 	Delete "$INSTDIR\Uninstall.exe"
-
-	RMDir "$INSTDIR\x86"
-	RMDir "$INSTDIR\x64"
 	RMDir "$INSTDIR"
 SectionEnd


### PR DESCRIPTION
Even though the installer is a 32 bit executable, it assumed it was running on a 64 bit system and tried to write 64 bit registry entries for the 64 bit build.
Fixes #4.